### PR TITLE
Merge distrobox export

### DIFF
--- a/ContainerFiles/boxkit
+++ b/ContainerFiles/boxkit
@@ -9,7 +9,7 @@ LABEL com.github.containers.toolbox="true" \
 COPY ../scripts/boxkit.sh /
 COPY ../scripts/distrobox-shims.sh /
 COPY ../packages/boxkit.packages /
-
+COPY ../scripts/alpineexport.sh /opt/
 # Run the setup scripts
 RUN chmod +x boxkit.sh distrobox-shims.sh && /boxkit.sh
 RUN rm /boxkit.sh /distrobox-shims.sh /boxkit.packages

--- a/scripts/alpineexport.sh
+++ b/scripts/alpineexport.sh
@@ -1,0 +1,25 @@
+#!/bin/bash
+
+distrobox-export --bin /usr/bin/elinks
+distrobox-export --bin /usr/bin/newsboat
+distrobox-export --bin /usr/bin/chezmoi
+distrobox-export --bin /usr/bin/youtube-tui
+distrobox-export --bin /usr/bin/tmux
+distrobox-export --bin /usr/bin/nvim
+distrobox-export --bin /usr/bin/btop
+distrobox-export --bin /usr/bin/vimdiff
+distrobox-export --bin /usr/bin/cosign
+distrobox-export --bin /usr/bin/yazi
+distrobox-export --bin /usr/bin/vncviewer
+distrobox-export --bin /usr/bin/mpv
+distrobox-export --bin /usr/bin/chafa
+distrobox-export --bin /usr/bin/fbi
+distrobox-export --bin /usr/bin/fbgs
+distrobox-export --bin /usr/bin/zathura
+distrobox-export --bin /usr/bin/imv
+distrobox-export --bin /usr/bin/alpine
+distrobox-export --bin /usr/bin/elinks
+distrobox-export --bin /usr/bin/lynx
+distrobox-export --bin /usr/bin/yt-dlp
+distrobox-export --bin /usr/bin/bombadillo
+distrobox-export --bin /usr/bin/newsboat


### PR DESCRIPTION
Add a script in /opt in the container that exports useful binaries to the host. The user can choose to run this if they want to be able to access the binaries without needing to enter the distrobox