### PR TITLE
Add tree-sitter-cli

### DIFF
--- a/packages/boxkit.packages
+++ b/packages/boxkit.packages
@@ -33,6 +33,7 @@ github-cli
 clang22
 clang22-extra-tools
 tree-sitter
+tree-sitter-cli
 tree-sitter-c
 tree-sitter-cpp
 curl 


### PR DESCRIPTION
Add tree-sitter-cli for neovim syntax highlighting and formatting
